### PR TITLE
Handle zero-distance embeddings

### DIFF
--- a/src/pathfinding/PathfinderProvider.ts
+++ b/src/pathfinding/PathfinderProvider.ts
@@ -127,13 +127,10 @@ export default class PathfinderProvider {
               continue;
             }
 
-            const embedding = this.segmentDistToPoint(from, to, p);
-            if (embedding) {
-              const distance = this.segmentDistToPoint(from, to, p);
-              if (distance < bestDistance) {
-                bestDistance = distance;
-                bestSegment = [way, from, to];
-              }
+            const distance = this.segmentDistToPoint(from, to, p);
+            if (distance < bestDistance) {
+              bestDistance = distance;
+              bestSegment = [way, from, to];
             }
           }
         }


### PR DESCRIPTION
This happens if input coordinates are based on the same data as the road network. Without this fix, points that match the road network are embedded to the second-closest way.

The bug is that when `embedding` (same as `distance`) is 0, `if (embedding)` does not pass even though it's a valid value. In the case that there really is no distance, `distance` will be Infinity instead and thus `if (distance < bestDistance)` never passes anyway.