### PR TITLE
Fix reconstruction of simple Dijkstra pathfinding

### DIFF
--- a/src/pathfinding/dijkstra/DijkstraInstance.ts
+++ b/src/pathfinding/dijkstra/DijkstraInstance.ts
@@ -120,8 +120,8 @@ export class DijkstraInstance implements IShortestPathInstance {
             let way;
 
             for (const edge of this.graph.getReverseAdjacencyList()[currentPosition]) {
-                if (this.getCost(edge.node) < nextPositionCost) {
-                    nextPositionCost = this.getCost(edge.node);
+                if (this.getCost(edge.node) + edge.cost < nextPositionCost) {
+                    nextPositionCost = this.getCost(edge.node) + edge.cost;
                     nextEdge = edge;
                     way = edge.through;
                 }


### PR DESCRIPTION
When following the found path backwards from the destination, choose the edge and node that together have the least cost to the origin.